### PR TITLE
Inheritance check fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 
+## v0.2.4
+* Fixed inheritance validation with multi AnyOf classes.
+
+
 ## v0.2.3
 * issue #40: Fixed inheritance validation as well as removing duplicate items from array's (like AnyOf).
 


### PR DESCRIPTION
When defining more then one class (curie) under the `<any-of>` option it generate php classes the wrong way. For example:

```xml
<field name="comment" type="message">
  <any-of>
    <curie>acme:core::user<curie>
    <curie>acme:core::group</curie>
  </any-of>
</field>
```
Generated:

```php
class AcmeCoreGroupV100 {};
class AcmeCoreUserV100 extends AcmeCoreGroupV100  {};
```

After the fix:

```php
class AcmeCoreUserV100 {};
class AcmeCoreGroupV100 {};
```
