### PR TITLE
Fixed duplicate class names in message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ## v0.2.5
-* Fixed duplicate class names when generating messages.
+* Force aliasing "use" statements of mixins when generating message classes.
 
 
 ## v0.2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 
+## v0.2.5
+* Fixed duplicate class names when generating messages.
+
+
 ## v0.2.4
 * Fixed inheritance validation with multi AnyOf classes.
 

--- a/examples/schemas/acme/user/command/create-user/1-0-0.xml
+++ b/examples/schemas/acme/user/command/create-user/1-0-0.xml
@@ -7,6 +7,7 @@
     <mixins>
       <curie-major>gdbots:pbjx:mixin:command:v1</curie-major>
       <curie-major>gdbots:ncr:mixin:create-node:v1</curie-major>
+      <curie-major>gdbots:iam:mixin:create-user:v1</curie-major>
       <curie-major>acme:user:mixin:create-user:v1</curie-major>
     </mixins>
 

--- a/examples/schemas/acme/user/command/create-user/1-0-0.xml
+++ b/examples/schemas/acme/user/command/create-user/1-0-0.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<pbj-schema xmlns="http://gdbots.io/pbj/xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://gdbots.io/pbj/xsd http://gdbots.io/pbj/xsd/schema.xsd">
+
+  <schema id="pbj:acme:user:command:create-user:1-0-0">
+    <mixins>
+      <curie-major>gdbots:pbjx:mixin:command:v1</curie-major>
+      <curie-major>gdbots:ncr:mixin:create-node:v1</curie-major>
+      <curie-major>acme:user:mixin:create-user:v1</curie-major>
+    </mixins>
+
+    <php-options>
+      <namespace>Acme\Schemas\User\Command\CreateUser</namespace>
+    </php-options>
+  </schema>
+</pbj-schema>

--- a/examples/schemas/acme/user/command/create-user/latest.xml
+++ b/examples/schemas/acme/user/command/create-user/latest.xml
@@ -7,6 +7,7 @@
     <mixins>
       <curie-major>gdbots:pbjx:mixin:command:v1</curie-major>
       <curie-major>gdbots:ncr:mixin:create-node:v1</curie-major>
+      <curie-major>gdbots:iam:mixin:create-user:v1</curie-major>
       <curie-major>acme:user:mixin:create-user:v1</curie-major>
     </mixins>
 

--- a/examples/schemas/acme/user/command/create-user/latest.xml
+++ b/examples/schemas/acme/user/command/create-user/latest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<pbj-schema xmlns="http://gdbots.io/pbj/xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://gdbots.io/pbj/xsd http://gdbots.io/pbj/xsd/schema.xsd">
+
+  <schema id="pbj:acme:user:command:create-user:1-0-0">
+    <mixins>
+      <curie-major>gdbots:pbjx:mixin:command:v1</curie-major>
+      <curie-major>gdbots:ncr:mixin:create-node:v1</curie-major>
+      <curie-major>acme:user:mixin:create-user:v1</curie-major>
+    </mixins>
+
+    <php-options>
+      <namespace>Acme\Schemas\User\Command\CreateUser</namespace>
+    </php-options>
+  </schema>
+</pbj-schema>

--- a/src/Generator/templates/php/message.twig
+++ b/src/Generator/templates/php/message.twig
@@ -21,8 +21,8 @@ use {{ field.language('php').get('classname') }};
 {% for mixin in schema.mixins %}
 {% if not isSameNamespace(schema, mixin) %}
 use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true) }};
-use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor ~ 'Mixin', true) }}Mixin;
-use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor ~ 'Trait', true) }}Trait;
+use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true, 'Mixin') }};
+use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true, 'Trait') }};
 {% endif %}
 {% endfor %}
 {% if format_class %}
@@ -49,7 +49,7 @@ final class {{ classNameVMajor }} extends AbstractMessage implements
 {
 {% block class_body %}
 {% for mixin in schema.mixins %}
-    use {{ getClassName(mixin, true, classNameVMajor ~ 'Trait') }}Trait;
+    use {{ getClassName(mixin, true, classNameVMajor, false, 'Trait') }};
 {% endfor %}
 
     /**
@@ -73,7 +73,7 @@ final class {{ classNameVMajor }} extends AbstractMessage implements
 {% if schema.mixins|length %}
             [
 {% for mixin in schema.mixins %}
-                {{ getClassName(mixin, true, classNameVMajor ~ 'Mixin') }}Mixin::create(){% if not loop.last %}, {% endif %}
+                {{ getClassName(mixin, true, classNameVMajor, false, 'Mixin') }}::create(){% if not loop.last %}, {% endif %}
 
 {% endfor %}
             ]

--- a/src/Generator/templates/php/message.twig
+++ b/src/Generator/templates/php/message.twig
@@ -21,8 +21,8 @@ use {{ field.language('php').get('classname') }};
 {% for mixin in schema.mixins %}
 {% if not isSameNamespace(schema, mixin) %}
 use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true) }};
-use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true) }}Mixin;
-use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true) }}Trait;
+use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true) }}Mixin;
+use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true) }}Trait;
 {% endif %}
 {% endfor %}
 {% if format_class %}
@@ -49,7 +49,7 @@ final class {{ classNameVMajor }} extends AbstractMessage implements
 {
 {% block class_body %}
 {% for mixin in schema.mixins %}
-    use {{ getClassName(mixin, true) }}Trait;
+    use {{ getClassName(mixin, true, classNameVMajor) }}Trait;
 {% endfor %}
 
     /**
@@ -73,7 +73,7 @@ final class {{ classNameVMajor }} extends AbstractMessage implements
 {% if schema.mixins|length %}
             [
 {% for mixin in schema.mixins %}
-                {{ getClassName(mixin, true) }}Mixin::create(){% if not loop.last %}, {% endif %}
+                {{ getClassName(mixin, true, classNameVMajor) }}Mixin::create(){% if not loop.last %}, {% endif %}
 
 {% endfor %}
             ]

--- a/src/Generator/templates/php/message.twig
+++ b/src/Generator/templates/php/message.twig
@@ -21,8 +21,8 @@ use {{ field.language('php').get('classname') }};
 {% for mixin in schema.mixins %}
 {% if not isSameNamespace(schema, mixin) %}
 use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true) }};
-use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true, 'Mixin') }};
-use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true, 'Trait') }};
+use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true, 'Mixin') }}Mixin;
+use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true, 'Trait') }}Trait;
 {% endif %}
 {% endfor %}
 {% if format_class %}
@@ -49,7 +49,7 @@ final class {{ classNameVMajor }} extends AbstractMessage implements
 {
 {% block class_body %}
 {% for mixin in schema.mixins %}
-    use {{ getClassName(mixin, true, classNameVMajor, false, 'Trait') }};
+    use {{ getClassName(mixin, true, classNameVMajor) }}Trait;
 {% endfor %}
 
     /**
@@ -73,7 +73,7 @@ final class {{ classNameVMajor }} extends AbstractMessage implements
 {% if schema.mixins|length %}
             [
 {% for mixin in schema.mixins %}
-                {{ getClassName(mixin, true, classNameVMajor, false, 'Mixin') }}::create(){% if not loop.last %}, {% endif %}
+                {{ getClassName(mixin, true, classNameVMajor) }}Mixin::create(){% if not loop.last %}, {% endif %}
 
 {% endfor %}
             ]

--- a/src/Generator/templates/php/message.twig
+++ b/src/Generator/templates/php/message.twig
@@ -21,8 +21,8 @@ use {{ field.language('php').get('classname') }};
 {% for mixin in schema.mixins %}
 {% if not isSameNamespace(schema, mixin) %}
 use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true) }};
-use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true) }}Mixin;
-use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true) }}Trait;
+use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor ~ 'Mixin', true) }}Mixin;
+use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor ~ 'Trait', true) }}Trait;
 {% endif %}
 {% endfor %}
 {% if format_class %}
@@ -49,7 +49,7 @@ final class {{ classNameVMajor }} extends AbstractMessage implements
 {
 {% block class_body %}
 {% for mixin in schema.mixins %}
-    use {{ getClassName(mixin, true, classNameVMajor) }}Trait;
+    use {{ getClassName(mixin, true, classNameVMajor ~ 'Trait') }}Trait;
 {% endfor %}
 
     /**
@@ -73,7 +73,7 @@ final class {{ classNameVMajor }} extends AbstractMessage implements
 {% if schema.mixins|length %}
             [
 {% for mixin in schema.mixins %}
-                {{ getClassName(mixin, true, classNameVMajor) }}Mixin::create(){% if not loop.last %}, {% endif %}
+                {{ getClassName(mixin, true, classNameVMajor ~ 'Mixin') }}Mixin::create(){% if not loop.last %}, {% endif %}
 
 {% endfor %}
             ]

--- a/src/Twig/Extension/SchemaExtension.php
+++ b/src/Twig/Extension/SchemaExtension.php
@@ -44,11 +44,10 @@ class SchemaExtension extends \Twig_Extension
 
         if ($baseClassName == $className) {
             $classNameBase = sprintf(
-                '%s%s%s%s',
+                '%s%s%s',
                 StringUtils::toCamelFromSlug($schema->getId()->getVendor()),
                 StringUtils::toCamelFromSlug($schema->getId()->getPackage()),
-                $className,
-                $postfix
+                $className
             );
 
             if ($withAs) {

--- a/src/Twig/Extension/SchemaExtension.php
+++ b/src/Twig/Extension/SchemaExtension.php
@@ -26,10 +26,11 @@ class SchemaExtension extends \Twig_Extension
      * @param bool             $majorRev
      * @param string           $baseClassName
      * @param bool             $withAs
+     * @param string           $postfix
      *
      * @return string
      */
-    public function getClassName(SchemaDescriptor $schema, $majorRev = false, $baseClassName = null, $withAs = false)
+    public function getClassName(SchemaDescriptor $schema, $majorRev = false, $baseClassName = null, $withAs = false, $postfix = null)
     {
         $className = StringUtils::toCamelFromSlug($schema->getId()->getMessage());
 
@@ -43,14 +44,15 @@ class SchemaExtension extends \Twig_Extension
 
         if ($baseClassName == $className) {
             $classNameBase = sprintf(
-                '%s%s%s',
+                '%s%s%s%s',
                 StringUtils::toCamelFromSlug($schema->getId()->getVendor()),
                 StringUtils::toCamelFromSlug($schema->getId()->getPackage()),
-                $className
+                $className,
+                $postfix
             );
 
             if ($withAs) {
-                $className = sprintf('%s as %s', $className, $classNameBase);
+                $className = sprintf('%s%s as %s', $className, $postfix, $classNameBase);
             } else {
                 $className = $classNameBase;
             }


### PR DESCRIPTION
This is to solve a case when including for example multi mixins with the same message name:
```xml
    <mixins>
      <curie-major>gdbots:iam:mixin:create-user:v1</curie-major>
      <curie-major>acme:user:mixin:create-user:v1</curie-major>
    </mixins>
```

Resolve in:
```php
use Gdbots\Schemas\Iam\Mixin\CreateUser\CreateUserV1 as GdbotsIamCreateUserV1;
use Gdbots\Schemas\Iam\Mixin\CreateUser\CreateUserV1Mixin as GdbotsIamCreateUserV1Mixin;
use Gdbots\Schemas\Iam\Mixin\CreateUser\CreateUserV1Trait as GdbotsIamCreateUserV1Trait;

use Acme\Schemas\User\Mixin\CreateUser\CreateUserV1 as AcmeUserCreateUserV1;
use Acme\Schemas\User\Mixin\CreateUser\CreateUserV1Mixin as AcmeUserCreateUserV1Mixin;
use Acme\Schemas\User\Mixin\CreateUser\CreateUserV1Trait as AcmeUserCreateUserV1Trait;
```