### PR TITLE
Force aliasing for all mixins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 
+## v0.2.6
+* Use aliasing "use" statements everywhere mixins are use.
+* Ignore adding trait classes to messages if schema doesn't include mixins and no insertion-points was define.
+
+
 ## v0.2.5
 * Force aliasing "use" statements of mixins when generating message classes.
 

--- a/examples/schemas/acme/user/mixin/create-user/1-0-0.xml
+++ b/examples/schemas/acme/user/mixin/create-user/1-0-0.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://gdbots.io/pbj/xsd http://gdbots.io/pbj/xsd/schema.xsd">
 
-  <schema id="pbj:acme:user:mixin:create-user:1-0-0" mixin="true" extends="gdbots:ncr:mixin:create-node:v1">
+  <schema id="pbj:acme:user:mixin:create-user:1-0-0" mixin="true" extends="gdbots:iam:mixin:create-user:v1">
     <fields>
       <field name="node" type="message" required="true">
         <any-of>
@@ -14,6 +14,20 @@
 
     <php-options>
       <namespace>Acme\Schemas\User\Mixin\CreateUser</namespace>
+      <insertion-points>
+        <imports/>
+        <methods>
+          <![CDATA[
+/**
+ * @return array
+ */
+public function getUriTemplateVars()
+{
+    return ['node' => (string)$this->get('node')];
+}
+            ]]>
+        </methods>
+      </insertion-points>
     </php-options>
   </schema>
 </pbj-schema>

--- a/examples/schemas/acme/user/mixin/create-user/latest.xml
+++ b/examples/schemas/acme/user/mixin/create-user/latest.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://gdbots.io/pbj/xsd http://gdbots.io/pbj/xsd/schema.xsd">
 
-  <schema id="pbj:acme:user:mixin:create-user:1-0-0" mixin="true" extends="gdbots:ncr:mixin:create-node:v1">
+  <schema id="pbj:acme:user:mixin:create-user:1-0-0" mixin="true" extends="gdbots:iam:mixin:create-user:v1">
     <fields>
       <field name="node" type="message" required="true">
         <any-of>
@@ -14,6 +14,20 @@
 
     <php-options>
       <namespace>Acme\Schemas\User\Mixin\CreateUser</namespace>
+      <insertion-points>
+        <imports/>
+        <methods>
+          <![CDATA[
+/**
+ * @return array
+ */
+public function getUriTemplateVars()
+{
+    return ['node' => (string)$this->get('node')];
+}
+            ]]>
+        </methods>
+      </insertion-points>
     </php-options>
   </schema>
 </pbj-schema>

--- a/examples/schemas/acme/user/mixin/update-user/1-0-0.xml
+++ b/examples/schemas/acme/user/mixin/update-user/1-0-0.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<pbj-schema xmlns="http://gdbots.io/pbj/xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://gdbots.io/pbj/xsd http://gdbots.io/pbj/xsd/schema.xsd">
+
+  <schema id="pbj:acme:user:mixin:update-user:1-0-0" mixin="true" extends="gdbots:iam:mixin:update-user:v1">
+    <fields>
+      <field name="new_node" type="message" required="true">
+        <any-of>
+          <curie>gdbots:iam:mixin:user</curie>
+        </any-of>
+      </field>
+      <field name="old_node" type="message">
+        <description>
+          The entire node, as it appeared before it was modified.
+        </description>
+        <any-of>
+          <curie>gdbots:iam:mixin:user</curie>
+        </any-of>
+      </field>
+    </fields>
+
+    <php-options>
+      <namespace>Acme\Schemas\User\Mixin\UpdateUser</namespace>
+    </php-options>
+  </schema>
+</pbj-schema>

--- a/examples/schemas/acme/user/mixin/update-user/latest.xml
+++ b/examples/schemas/acme/user/mixin/update-user/latest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<pbj-schema xmlns="http://gdbots.io/pbj/xsd"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://gdbots.io/pbj/xsd http://gdbots.io/pbj/xsd/schema.xsd">
+
+  <schema id="pbj:acme:user:mixin:update-user:1-0-0" mixin="true" extends="gdbots:iam:mixin:update-user:v1">
+    <fields>
+      <field name="new_node" type="message" required="true">
+        <any-of>
+          <curie>gdbots:iam:mixin:user</curie>
+        </any-of>
+      </field>
+      <field name="old_node" type="message">
+        <description>
+          The entire node, as it appeared before it was modified.
+        </description>
+        <any-of>
+          <curie>gdbots:iam:mixin:user</curie>
+        </any-of>
+      </field>
+    </fields>
+
+    <php-options>
+      <namespace>Acme\Schemas\User\Mixin\UpdateUser</namespace>
+    </php-options>
+  </schema>
+</pbj-schema>

--- a/src/Generator/PhpGenerator.php
+++ b/src/Generator/PhpGenerator.php
@@ -79,18 +79,25 @@ class PhpGenerator extends Generator
      */
     protected function getSchemaTemplates(SchemaDescriptor $schema)
     {
-        return $schema->isMixinSchema()
-            ? [
+        $templates = [
+            'curie-interface.twig' => '{className}',
+            'message.twig' => '{className}V{major}',
+        ];
+
+        if ($schema->isMixinSchema()) {
+            $templates = [
                 'curie-interface.twig' => '{className}',
                 'curie-major-interface.twig' => '{className}V{major}',
                 'mixin.twig' => '{className}V{major}Mixin',
-                'trait.twig' => '{className}V{major}Trait',
-            ]
-            : [
-                'curie-interface.twig' => '{className}',
-                'message.twig' => '{className}V{major}',
-            ]
-        ;
+            ];
+
+            // ignore empty trait classes
+            if (count($schema->getMixins()) || $schema->getLanguage('php')->get('insertion-points')) {
+                $templates['trait.twig'] = '{className}V{major}Trait';
+            }
+        }
+
+        return $templates;
     }
 
     /**

--- a/src/Generator/templates/php/curie-interface.twig
+++ b/src/Generator/templates/php/curie-interface.twig
@@ -1,18 +1,17 @@
-{% set className = getClassName(schema) %}
 <?php
 
 namespace {{ schema.language('php').get('namespace') }};
 
 {% block use_statements %}
 {% if schema.extends and not isSameNamespace(schema, schema.extends) %}
-use {{ schema.extends.language('php').get('namespace') }}\{% if not hasOtherMajorRev(schema) %}{{ getClassName(schema.extends, true) }}{% else %}{{ getClassName(schema.extends, false, className, true) }}{% endif %};
+use {{ schema.extends.language('php').get('namespace') }}\{% if not hasOtherMajorRev(schema) %}{{ getClassName(schema.extends, true) }}{% else %}{{ getClassName(schema.extends, false, true, true) }}{% endif %};
 {% else %}
 use Gdbots\Pbj\Message;
 {% endif %}
 {% endblock use_statements %}
 
 {% block class_definition %}
-interface {{ className }} extends {% if schema.extends %}{% if not hasOtherMajorRev(schema) %}{{ getClassName(schema.extends, true) }}{% else %}{{ getClassName(schema.extends, false, className) }}{% endif %}{% else %}Message{% endif %}
+interface {{ getClassName(schema) }} extends {% if schema.extends %}{% if not hasOtherMajorRev(schema) %}{{ getClassName(schema.extends, true) }}{% else %}{{ getClassName(schema.extends, false, true) }}{% endif %}{% else %}Message{% endif %}
 
 {% endblock class_definition %}
 {

--- a/src/Generator/templates/php/curie-major-interface.twig
+++ b/src/Generator/templates/php/curie-major-interface.twig
@@ -1,16 +1,15 @@
-{% set classNameVMajor = getClassName(schema, true) %}
 <?php
 
 namespace {{ schema.language('php').get('namespace') }};
 
 {% block use_statements %}
 {% if hasOtherMajorRev(schema) and schema.extends and not isSameNamespace(schema, schema.extends) %}
-use {{ schema.extends.language('php').get('namespace') }}\{{ getClassName(schema.extends, true, classNameVMajor, true) }};
+use {{ schema.extends.language('php').get('namespace') }}\{{ getClassName(schema.extends, true, true, true) }};
 {% endif %}
 {% endblock use_statements %}
 
 {% block class_definition %}
-interface {{ classNameVMajor }} extends {% if hasOtherMajorRev(schema) and schema.extends %}{{ getClassName(schema) }}, {{ getClassName(schema.extends, true, classNameVMajor) }}{% else %}{{ getClassName(schema) }}{% endif %}
+interface {{ getClassName(schema, true) }} extends {% if hasOtherMajorRev(schema) and schema.extends %}{{ getClassName(schema) }}, {{ getClassName(schema.extends, true, true) }}{% else %}{{ getClassName(schema) }}{% endif %}
 
 {% endblock class_definition %}
 {

--- a/src/Generator/templates/php/message.twig
+++ b/src/Generator/templates/php/message.twig
@@ -1,4 +1,3 @@
-{% set classNameVMajor = getClassName(schema, true) %}
 {% set insertionPoints = schema.language('php').get('insertion-points') %}
 <?php
 
@@ -20,9 +19,11 @@ use {{ field.language('php').get('classname') }};
 {% endfor %}
 {% for mixin in schema.mixins %}
 {% if not isSameNamespace(schema, mixin) %}
-use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true) }};
-use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true, 'Mixin') }}Mixin;
-use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, classNameVMajor, true, 'Trait') }}Trait;
+use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, true, true) }};
+use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, true, true, 'Mixin') }};
+{% if mixin.mixins|length or mixin.language('php').get('insertion-points') %}
+use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, true, true, 'Trait') }};
+{% endif %}
 {% endif %}
 {% endfor %}
 {% if format_class %}
@@ -34,11 +35,11 @@ use Gdbots\Pbj\Enum\Format;
 {% endblock use_statements %}
 
 {% block class_definition %}
-final class {{ classNameVMajor }} extends AbstractMessage implements
+final class {{ getClassName(schema, true) }} extends AbstractMessage implements
     {{ getClassName(schema) }}{% if schema.mixins|length %},{% endif %}
 
 {% for mixin in schema.mixins %}
-    {{ getClassName(mixin, true, classNameVMajor) }}{% if not loop.last %},{% endif %}
+    {{ getClassName(mixin, true, true) }}{% if not loop.last %},{% endif %}
 
 {% endfor %}
 {% if schema.mixins|length %}
@@ -49,7 +50,9 @@ final class {{ classNameVMajor }} extends AbstractMessage implements
 {
 {% block class_body %}
 {% for mixin in schema.mixins %}
-    use {{ getClassName(mixin, true, classNameVMajor) }}Trait;
+{% if mixin.mixins|length or mixin.language('php').get('insertion-points') %}
+    use {{ getClassName(mixin, true, true, false, 'Trait') }};
+{% endif %}
 {% endfor %}
 
     /**
@@ -73,7 +76,7 @@ final class {{ classNameVMajor }} extends AbstractMessage implements
 {% if schema.mixins|length %}
             [
 {% for mixin in schema.mixins %}
-                {{ getClassName(mixin, true, classNameVMajor) }}Mixin::create(){% if not loop.last %}, {% endif %}
+                {{ getClassName(mixin, true, true, false, 'Mixin') }}::create(){% if not loop.last %}, {% endif %}
 
 {% endfor %}
             ]

--- a/src/Generator/templates/php/trait.twig
+++ b/src/Generator/templates/php/trait.twig
@@ -7,7 +7,7 @@ namespace {{ schema.language('php').get('namespace') }};
 use Gdbots\Pbj\Schema;
 {% for mixin in schema.mixins %}
 {% if not isSameNamespace(schema, mixin) %}
-use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true) }}Trait;
+use {{ mixin.language('php').get('namespace') }}\{{ getClassName(mixin, true, true, true, 'Trait') }};
 {% endif %}
 {% endfor %}
 {% if insertionPoints %}
@@ -25,7 +25,7 @@ trait {{ getClassName(schema, true) }}Trait
 {
 {% block class_body %}
 {% for mixin in schema.mixins %}
-    use {{ getClassName(mixin, true) }}Trait;
+    use {{ getClassName(mixin, true, true, false, 'Trait') }};
 {% endfor %}
 
 {% if insertionPoints %}

--- a/src/Twig/Extension/SchemaExtension.php
+++ b/src/Twig/Extension/SchemaExtension.php
@@ -24,13 +24,13 @@ class SchemaExtension extends \Twig_Extension
     /**
      * @param SchemaDescriptor $schema
      * @param bool             $majorRev
-     * @param string           $baseClassName
+     * @param bool             $addBase
      * @param bool             $withAs
      * @param string           $postfix
      *
      * @return string
      */
-    public function getClassName(SchemaDescriptor $schema, $majorRev = false, $baseClassName = null, $withAs = false, $postfix = null)
+    public function getClassName(SchemaDescriptor $schema, $majorRev = false, $addBase = false, $withAs = false, $postfix = null)
     {
         $className = StringUtils::toCamelFromSlug($schema->getId()->getMessage());
 
@@ -42,19 +42,21 @@ class SchemaExtension extends \Twig_Extension
             );
         }
 
-        if ($baseClassName == $className) {
-            $classNameBase = sprintf(
+        $newClassName = $className;
+
+        if ($addBase) {
+            $newClassName = sprintf(
                 '%s%s%s',
                 StringUtils::toCamelFromSlug($schema->getId()->getVendor()),
                 StringUtils::toCamelFromSlug($schema->getId()->getPackage()),
                 $className
             );
+        }
 
-            if ($withAs) {
-                $className = sprintf('%s%s as %s', $className, $postfix, $classNameBase);
-            } else {
-                $className = $classNameBase;
-            }
+        if ($withAs) {
+            $className = sprintf('%s%s as %s%s', $className, $postfix, $newClassName, $postfix);
+        } else {
+            $className = sprintf('%s%s', $newClassName, $postfix);
         }
 
         return $className;

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -51,6 +51,6 @@ class CompilerTest extends \PHPUnit_Framework_TestCase
             },
         ]));
 
-        $this->assertEquals(15, $count);
+        $this->assertEquals(14, $count);
     }
 }


### PR DESCRIPTION
- Use aliasing "use" statements everywhere mixins are use.
- Ignore adding trait classes to messages if schema doesn't include mixins and no insertion-points was define.

Example:
```php
<?php

namespace Acme\Schemas\User\Command\CreateUser;

use Acme\Schemas\User\Mixin\CreateUser\CreateUserV1 as AcmeUserCreateUserV1;
use Acme\Schemas\User\Mixin\CreateUser\CreateUserV1Mixin as AcmeUserCreateUserV1Mixin;
use Acme\Schemas\User\Mixin\CreateUser\CreateUserV1Trait as AcmeUserCreateUserV1Trait;
use Gdbots\Pbj\AbstractMessage;
use Gdbots\Pbj\FieldBuilder as Fb;
use Gdbots\Pbj\Schema;
use Gdbots\Pbj\Type as T;
use Gdbots\Schemas\Iam\Mixin\CreateUser\CreateUserV1 as GdbotsIamCreateUserV1;
use Gdbots\Schemas\Iam\Mixin\CreateUser\CreateUserV1Mixin as GdbotsIamCreateUserV1Mixin;
use Gdbots\Schemas\Ncr\Mixin\CreateNode\CreateNodeV1 as GdbotsNcrCreateNodeV1;
use Gdbots\Schemas\Ncr\Mixin\CreateNode\CreateNodeV1Mixin as GdbotsNcrCreateNodeV1Mixin;
use Gdbots\Schemas\Pbjx\Mixin\Command\CommandV1 as GdbotsPbjxCommandV1;
use Gdbots\Schemas\Pbjx\Mixin\Command\CommandV1Mixin as GdbotsPbjxCommandV1Mixin;
use Gdbots\Schemas\Pbjx\Mixin\Command\CommandV1Trait as GdbotsPbjxCommandV1Trait;

final class CreateUserV1 extends AbstractMessage implements
    CreateUser,
    GdbotsPbjxCommandV1,
    GdbotsNcrCreateNodeV1,
    GdbotsIamCreateUserV1,
    AcmeUserCreateUserV1
  
{
    use GdbotsPbjxCommandV1Trait;
    use AcmeUserCreateUserV1Trait;

    /**
     * @return Schema
     */
    protected static function defineSchema()
    {
        return new Schema('pbj:acme:user:command:create-user:1-0-0', __CLASS__,
            [],
            [
                GdbotsPbjxCommandV1Mixin::create(), 
                GdbotsNcrCreateNodeV1Mixin::create(), 
                GdbotsIamCreateUserV1Mixin::create(), 
                AcmeUserCreateUserV1Mixin::create()
            ]
        );
    }
}
```