### PR TITLE
v0.4.0 - one manfiest to rule them all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 
+## v0.4.0
+* Generate one manifest instead of using manifest groups as they don't align with the strategy of one manifest to rule them all for optimal resolution at runtime.
+
+
 ## v0.3.3
 * issue #46: Fix bug with with descriptors not always referencing latest schemas as they had their own references to objects that were changing during the parse phase. The fix is to always go back to the SchemaStore whenever a schema is needed.
 
@@ -41,7 +45,7 @@ __BREAKING CHANGES__
 
 
 ## v0.2.2
-* issue #38: Fixed identifier type json schema pattern to allow for "^[\w\/\.:-]+$".
+* issue #38: Fixed identifier type json schema pattern to allow for `^[\w\/\.:-]+$`.
 
 
 ## v0.2.1

--- a/src/Generator/Twig/php/manifest.twig
+++ b/src/Generator/Twig/php/manifest.twig
@@ -8,8 +8,20 @@
  * @link {{ compile_options.domain }}/
  */
 
-\Gdbots\Pbj\MessageResolver::registerMap([
-{% for curie, schema in schemas %}
-    '{{ curie }}' => '{{ schema_to_native_namespace(schema) }}\{{ schema_to_class_name(schema, true) }}',
+\Gdbots\Pbj\MessageResolver::registerManifest([
+    'curies' => [
+{% for curie, id in manifest['curies'] %}
+        '{{ curie }}' => {{ id }},
 {% endfor %}
+    ],
+    'classes' => [
+{% for id, class in manifest['classes'] %}
+        {{ id }} => '{{ class }}',
+{% endfor %}
+    ],
+    'mixins' => [
+{% for curie, ids in manifest['mixins'] %}
+        '{{ curie }}' => [{{ ids|join(',') }}],
+{% endfor %}
+    ],
 ]);


### PR DESCRIPTION
* Generate one manifest instead of using manifest groups as they don't align with the strategy of one manifest to rule them all for optimal resolution at runtime.